### PR TITLE
Re-add license checks +  missing licenses

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -208,6 +208,8 @@
 Apache Polaris distributions contain some or all of the following dependencies,
 licensed under Apache License:
 
+com.aayushatharva.brotli4j:brotli4j
+com.aayushatharva.brotli4j:service
 com.fasterxml.jackson.core:jackson-annotations
 com.fasterxml.jackson.core:jackson-core
 com.fasterxml.jackson.core:jackson-databind
@@ -229,6 +231,7 @@ com.google.android:annotations
 com.google.api-client:google-api-client
 com.google.api.grpc:gapic-google-cloud-storage-v2
 com.google.api.grpc:grpc-google-cloud-storage-v2
+com.google.api.grpc:proto-google-cloud-monitoring-v3
 com.google.api.grpc:proto-google-cloud-storage-v2
 com.google.api.grpc:proto-google-common-protos
 com.google.api.grpc:proto-google-iam-v1
@@ -236,20 +239,19 @@ com.google.api:api-common
 com.google.api:gax
 com.google.api:gax-grpc
 com.google.api:gax-httpjson
-com.google.api.grpc:proto-google-cloud-monitoring-v3
 com.google.apis:google-api-services-storage
 com.google.auth:google-auth-library-credentials
 com.google.auth:google-auth-library-oauth2-http
 com.google.auto.value:auto-value-annotations
-com.google.cloud:google-cloud-core
-com.google.cloud:google-cloud-core-grpc
-com.google.cloud:google-cloud-core-http
-com.google.cloud:google-cloud-storage
-com.google.cloud:google-cloud-monitoring
 com.google.cloud.opentelemetry:detector-resources-support
 com.google.cloud.opentelemetry:exporter-metrics
 com.google.cloud.opentelemetry:shared-resourcemapping
+com.google.cloud:google-cloud-core
+com.google.cloud:google-cloud-core-grpc
+com.google.cloud:google-cloud-core-http
 com.google.cloud:google-cloud-monitorin
+com.google.cloud:google-cloud-monitoring
+com.google.cloud:google-cloud-storage
 com.google.code.findbugs:jsr305
 com.google.code.gson:gson
 com.google.errorprone:error_prone_annotations
@@ -313,6 +315,7 @@ io.grpc:grpc-core
 io.grpc:grpc-googleapis
 io.grpc:grpc-grpclb
 io.grpc:grpc-inprocess
+io.grpc:grpc-netty
 io.grpc:grpc-netty-shaded
 io.grpc:grpc-opentelemetry
 io.grpc:grpc-protobuf
@@ -326,9 +329,11 @@ io.micrometer:micrometer-commons
 io.micrometer:micrometer-core
 io.micrometer:micrometer-observation
 io.micrometer:micrometer-registry-prometheus
+io.micrometer:micrometer-registry-prometheus-simpleclient
 io.netty:netty-buffer
 io.netty:netty-codec
 io.netty:netty-codec-dns
+io.netty:netty-codec-haproxy
 io.netty:netty-codec-http
 io.netty:netty-codec-http2
 io.netty:netty-codec-socks
@@ -350,18 +355,30 @@ io.netty:netty-transport-native-unix-common
 io.opencensus:opencensus-api
 io.opencensus:opencensus-contrib-http-util
 io.opencensus:opencensus-proto
+io.opentelemetry.contrib:opentelemetry-gcp-resources
+io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations
+io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations-support
+io.opentelemetry.instrumentation:opentelemetry-instrumentation-api
+io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-incubator
+io.opentelemetry.instrumentation:opentelemetry-runtime-telemetry-java17
+io.opentelemetry.instrumentation:opentelemetry-runtime-telemetry-java8
 io.opentelemetry.semconv:opentelemetry-semconv
+io.opentelemetry.semconv:opentelemetry-semconv-incubating
 io.opentelemetry:opentelemetry-api
 io.opentelemetry:opentelemetry-api-incubator
 io.opentelemetry:opentelemetry-context
+io.opentelemetry:opentelemetry-exporter-common
 io.opentelemetry:opentelemetry-exporter-logging
+io.opentelemetry:opentelemetry-exporter-otlp
+io.opentelemetry:opentelemetry-exporter-otlp-common
+io.opentelemetry:opentelemetry-exporter-sender-okhttp
 io.opentelemetry:opentelemetry-sdk
 io.opentelemetry:opentelemetry-sdk-common
+io.opentelemetry:opentelemetry-sdk-extension-autoconfigure
 io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi
 io.opentelemetry:opentelemetry-sdk-logs
 io.opentelemetry:opentelemetry-sdk-metrics
 io.opentelemetry:opentelemetry-sdk-trace
-io.opentelemetry.contrib:opentelemetry-gcp-resources
 io.perfmark:perfmark-api
 io.projectreactor.netty:reactor-netty-core
 io.projectreactor.netty:reactor-netty-http
@@ -374,10 +391,103 @@ io.prometheus:prometheus-metrics-exposition-formats
 io.prometheus:prometheus-metrics-model
 io.prometheus:prometheus-metrics-shaded-protobuf
 io.prometheus:prometheus-metrics-tracer-common
+io.prometheus:simpleclient
+io.prometheus:simpleclient_common
+io.prometheus:simpleclient_tracer_common
+io.prometheus:simpleclient_tracer_otel
+io.prometheus:simpleclient_tracer_otel_agent
+io.quarkus.arc:arc
+io.quarkus.resteasy.reactive:resteasy-reactive
+io.quarkus.resteasy.reactive:resteasy-reactive-common
+io.quarkus.resteasy.reactive:resteasy-reactive-common-types
+io.quarkus.resteasy.reactive:resteasy-reactive-jackson
+io.quarkus.resteasy.reactive:resteasy-reactive-vertx
+io.quarkus.security:quarkus-security
+io.quarkus.vertx.utils:quarkus-vertx-utils
+io.quarkus:quarkus-arc
+io.quarkus:quarkus-bootstrap-runner
+io.quarkus:quarkus-classloader-commons
+io.quarkus:quarkus-container-image
+io.quarkus:quarkus-container-image-docker
+io.quarkus:quarkus-container-image-docker-common
+io.quarkus:quarkus-core
+io.quarkus:quarkus-credentials
+io.quarkus:quarkus-development-mode-spi
+io.quarkus:quarkus-fs-util
+io.quarkus:quarkus-grpc-common
+io.quarkus:quarkus-hibernate-validator
+io.quarkus:quarkus-ide-launcher
+io.quarkus:quarkus-jackson
+io.quarkus:quarkus-jsonp
+io.quarkus:quarkus-logging-json
+io.quarkus:quarkus-micrometer
+io.quarkus:quarkus-micrometer-registry-prometheus
+io.quarkus:quarkus-mutiny
+io.quarkus:quarkus-netty
+io.quarkus:quarkus-opentelemetry
+io.quarkus:quarkus-reactive-routes
+io.quarkus:quarkus-rest
+io.quarkus:quarkus-rest-common
+io.quarkus:quarkus-rest-jackson
+io.quarkus:quarkus-rest-jackson-common
+io.quarkus:quarkus-security-runtime-spi
+io.quarkus:quarkus-smallrye-context-propagation
+io.quarkus:quarkus-smallrye-health
+io.quarkus:quarkus-tls-registry
+io.quarkus:quarkus-vertx
+io.quarkus:quarkus-vertx-http
+io.quarkus:quarkus-vertx-latebound-mdc-provider
+io.quarkus:quarkus-virtual-threads
+io.smallrye.common:smallrye-common-annotation
+io.smallrye.common:smallrye-common-classloader
+io.smallrye.common:smallrye-common-constraint
+io.smallrye.common:smallrye-common-cpu
+io.smallrye.common:smallrye-common-expression
+io.smallrye.common:smallrye-common-function
+io.smallrye.common:smallrye-common-io
+io.smallrye.common:smallrye-common-net
+io.smallrye.common:smallrye-common-os
+io.smallrye.common:smallrye-common-ref
+io.smallrye.common:smallrye-common-vertx-context
+io.smallrye.config:smallrye-config
+io.smallrye.config:smallrye-config-common
+io.smallrye.config:smallrye-config-core
+io.smallrye.config:smallrye-config-validator
+io.smallrye.reactive:mutiny
+io.smallrye.reactive:mutiny-smallrye-context-propagation
+io.smallrye.reactive:mutiny-zero-flow-adapters
+io.smallrye.reactive:smallrye-mutiny-vertx-auth-common
+io.smallrye.reactive:smallrye-mutiny-vertx-bridge-common
+io.smallrye.reactive:smallrye-mutiny-vertx-core
+io.smallrye.reactive:smallrye-mutiny-vertx-runtime
+io.smallrye.reactive:smallrye-mutiny-vertx-uri-template
+io.smallrye.reactive:smallrye-mutiny-vertx-web
+io.smallrye.reactive:smallrye-mutiny-vertx-web-common
+io.smallrye.reactive:vertx-mutiny-generator
+io.smallrye:smallrye-context-propagation
+io.smallrye:smallrye-context-propagation-api
+io.smallrye:smallrye-context-propagation-storage
+io.smallrye:smallrye-fault-tolerance-vertx
+io.smallrye:smallrye-health
+io.smallrye:smallrye-health-api
+io.smallrye:smallrye-health-provided-checks
 io.swagger:swagger-annotations
 io.swagger:swagger-core
 io.swagger:swagger-jaxrs
 io.swagger:swagger-models
+io.vertx:vertx-auth-common
+io.vertx:vertx-bridge-common
+io.vertx:vertx-codegen
+io.vertx:vertx-core
+io.vertx:vertx-grpc
+io.vertx:vertx-grpc-client
+io.vertx:vertx-grpc-common
+io.vertx:vertx-grpc-server
+io.vertx:vertx-uri-template
+io.vertx:vertx-web
+io.vertx:vertx-web-common
+jakarta.enterprise:jakarta.enterprise.cdi-api
+jakarta.enterprise:jakarta.enterprise.lang-model
 jakarta.inject:jakarta.inject-api
 jakarta.validation:jakarta.validation-api
 javax.inject:javax.inject
@@ -396,13 +506,14 @@ org.apache.curator:curator-client
 org.apache.curator:curator-framework
 org.apache.curator:curator-recipes
 org.apache.hadoop.thirdparty:hadoop-shaded-guava
+org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_21
 org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7
 org.apache.hadoop:hadoop-annotations
 org.apache.hadoop:hadoop-auth
 org.apache.hadoop:hadoop-client-api
+org.apache.hadoop:hadoop-client-runtime
 org.apache.hadoop:hadoop-common
 org.apache.hadoop:hadoop-hdfs-client
-org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_21
 org.apache.httpcomponents.client5:httpclient5
 org.apache.httpcomponents.core5:httpcore5
 org.apache.httpcomponents.core5:httpcore5-h2
@@ -445,6 +556,9 @@ org.eclipse.jetty:jetty-servlets
 org.eclipse.jetty:jetty-util
 org.eclipse.jetty:jetty-webapp
 org.eclipse.jetty:jetty-xml
+org.eclipse.microprofile.config:microprofile-config-api
+org.eclipse.microprofile.context-propagation:microprofile-context-propagation-api
+org.eclipse.microprofile.health:microprofile-health-api
 org.glassfish.jersey.containers:jersey-container-servlet
 org.glassfish.jersey.containers:jersey-container-servlet-core
 org.glassfish.jersey.core:jersey-client
@@ -455,7 +569,13 @@ org.glassfish.jersey.ext:jersey-metainf-services
 org.glassfish.jersey.inject:jersey-hk2
 org.hibernate.validator:hibernate-validator
 org.javassist:javassist
+org.jboss.logging:commons-logging-jboss-logging
 org.jboss.logging:jboss-logging
+org.jboss.logging:jboss-logging-annotations
+org.jboss.logmanager:jboss-logmanager
+org.jboss.slf4j:slf4j-jboss-logmanager
+org.jboss.threads:jboss-threads
+org.jctools:jctools-core
 org.jetbrains.kotlin:kotlin-stdlib
 org.jetbrains.kotlin:kotlin-stdlib-common
 org.ow2.asm:asm
@@ -463,6 +583,7 @@ org.reflections:reflections
 org.roaringbitmap:RoaringBitmap
 org.slf4j:jcl-over-slf4j
 org.slf4j:log4j-over-slf4j
+org.wildfly.common:wildfly-common
 org.xerial.snappy:snappy-java
 org.yaml:snakeyaml
 software.amazon.awssdk:annotations
@@ -2678,9 +2799,41 @@ The project maintains the following source code repositories:
 
 
 ---
+io.github.crac:org-crac
+
+Copyright 2017-2022 Azul Systems, Inc.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+
+
+---
 jakarta.annotation:jakarta.annotation-api
 jakarta.el:jakarta.el-api
+jakarta.interceptor:jakarta.interceptor-api
+jakarta.json:jakarta.json-api
 jakarta.servlet:jakarta.servlet-api
+jakarta.transaction:jakarta.transaction-api
 jakarta.ws.rs:jakarta.ws.rs-api
 
 # Eclipse Public License - v 2.0
@@ -4386,6 +4539,8 @@ permitted.
 
 
 ---
+org.eclipse.parsson:jakarta.json
+org.eclipse.parsson:parsson
 org.eclipse.persistence:eclipselink
 
 Eclipse Public License - v 2.0
@@ -5367,6 +5522,286 @@ No other rights are granted by implication, estoppel or otherwise.
 Revision level 1.2, last updated on 2009/01/13
 Changed the URL of the Artifacts.
 Revision level 1.1, last updated on 2007/11/19
+
+
+---
+org.glassfish.expressly:expressly
+
+    THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+    PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+    OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+
+  a) in the case of the initial Contributor, the initial content
+     Distributed under this Agreement, and
+
+  b) in the case of each subsequent Contributor:
+     i) changes to the Program, and
+     ii) additions to the Program;
+  where such changes and/or additions to the Program originate from
+  and are Distributed by that particular Contributor. A Contribution
+  "originates" from a Contributor if it was added to the Program by
+  such Contributor itself or anyone acting on such Contributor's behalf.
+  Contributions do not include changes or additions to the Program that
+  are not Modified Works.
+
+"Contributor" means any person or entity that Distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which
+are necessarily infringed by the use or sale of its Contribution alone
+or when combined with the Program.
+
+"Program" means the Contributions Distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement
+or any Secondary License (as applicable), including Contributors.
+
+"Derivative Works" shall mean any work, whether in Source Code or other
+form, that is based on (or derived from) the Program and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship.
+
+"Modified Works" shall mean any work in Source Code or other form that
+results from an addition to, deletion from, or modification of the
+contents of the Program, including, for purposes of clarity any new file
+in Source Code form that contains any contents of the Program. Modified
+Works shall not include works that contain only declarations,
+interfaces, types, classes, structures, or files of the Program solely
+in each case in order to link to, bind by name, or subclass the Program
+or Modified Works thereof.
+
+"Distribute" means the acts of a) distributing or b) making available
+in any manner that enables the transfer of a copy.
+
+"Source Code" means the form of a Program preferred for making
+modifications, including but not limited to software source code,
+documentation source, and configuration files.
+
+"Secondary License" means either the GNU General Public License,
+Version 2.0, or any later versions of that license, including any
+exceptions or additional permissions as identified by the initial
+Contributor.
+
+2. GRANT OF RIGHTS
+
+  a) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free copyright
+  license to reproduce, prepare Derivative Works of, publicly display,
+  publicly perform, Distribute and sublicense the Contribution of such
+  Contributor, if any, and such Derivative Works.
+
+  b) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free patent
+  license under Licensed Patents to make, use, sell, offer to sell,
+  import and otherwise transfer the Contribution of such Contributor,
+  if any, in Source Code or other form. This patent license shall
+  apply to the combination of the Contribution and the Program if, at
+  the time the Contribution is added by the Contributor, such addition
+  of the Contribution causes such combination to be covered by the
+  Licensed Patents. The patent license shall not apply to any other
+  combinations which include the Contribution. No hardware per se is
+  licensed hereunder.
+
+  c) Recipient understands that although each Contributor grants the
+  licenses to its Contributions set forth herein, no assurances are
+  provided by any Contributor that the Program does not infringe the
+  patent or other intellectual property rights of any other entity.
+  Each Contributor disclaims any liability to Recipient for claims
+  brought by any other entity based on infringement of intellectual
+  property rights or otherwise. As a condition to exercising the
+  rights and licenses granted hereunder, each Recipient hereby
+  assumes sole responsibility to secure any other intellectual
+  property rights needed, if any. For example, if a third party
+  patent license is required to allow Recipient to Distribute the
+  Program, it is Recipient's responsibility to acquire that license
+  before distributing the Program.
+
+  d) Each Contributor represents that to its knowledge it has
+  sufficient copyright rights in its Contribution, if any, to grant
+  the copyright license set forth in this Agreement.
+
+  e) Notwithstanding the terms of any Secondary License, no
+  Contributor makes additional grants to any Recipient (other than
+  those set forth in this Agreement) as a result of such Recipient's
+  receipt of the Program under the terms of a Secondary License
+  (if permitted under the terms of Section 3).
+
+3. REQUIREMENTS
+
+3.1 If a Contributor Distributes the Program in any form, then:
+
+  a) the Program must also be made available as Source Code, in
+  accordance with section 3.2, and the Contributor must accompany
+  the Program with a statement that the Source Code for the Program
+  is available under this Agreement, and informs Recipients how to
+  obtain it in a reasonable manner on or through a medium customarily
+  used for software exchange; and
+
+  b) the Contributor may Distribute the Program under a license
+  different than this Agreement, provided that such license:
+     i) effectively disclaims on behalf of all other Contributors all
+     warranties and conditions, express and implied, including
+     warranties or conditions of title and non-infringement, and
+     implied warranties or conditions of merchantability and fitness
+     for a particular purpose;
+
+     ii) effectively excludes on behalf of all other Contributors all
+     liability for damages, including direct, indirect, special,
+     incidental and consequential damages, such as lost profits;
+
+     iii) does not attempt to limit or alter the recipients' rights
+     in the Source Code under section 3.2; and
+
+     iv) requires any subsequent distribution of the Program by any
+     party to be under a license that satisfies the requirements
+     of this section 3.
+
+3.2 When the Program is Distributed as Source Code:
+
+  a) it must be made available under this Agreement, or if the
+  Program (i) is combined with other material in a separate file or
+  files made available under a Secondary License, and (ii) the initial
+  Contributor attached to the Source Code the notice described in
+  Exhibit A of this Agreement, then the Program may be made available
+  under the terms of such Secondary Licenses, and
+
+  b) a copy of this Agreement must be included with each copy of
+  the Program.
+
+3.3 Contributors may not remove or alter any copyright, patent,
+trademark, attribution notices, disclaimers of warranty, or limitations
+of liability ("notices") contained within the Program from any copy of
+the Program which they Distribute, provided that Contributors may add
+their own appropriate notices.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities
+with respect to end users, business partners and the like. While this
+license is intended to facilitate the commercial use of the Program,
+the Contributor who includes the Program in a commercial product
+offering should do so in a manner which does not create potential
+liability for other Contributors. Therefore, if a Contributor includes
+the Program in a commercial product offering, such Contributor
+("Commercial Contributor") hereby agrees to defend and indemnify every
+other Contributor ("Indemnified Contributor") against any losses,
+damages and costs (collectively "Losses") arising from claims, lawsuits
+and other legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such
+Commercial Contributor in connection with its distribution of the Program
+in a commercial product offering. The obligations in this section do not
+apply to any claims or Losses relating to any actual or alleged
+intellectual property infringement. In order to qualify, an Indemnified
+Contributor must: a) promptly notify the Commercial Contributor in
+writing of such claim, and b) allow the Commercial Contributor to control,
+and cooperate with the Commercial Contributor in, the defense and any
+related settlement negotiations. The Indemnified Contributor may
+participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial
+product offering, Product X. That Contributor is then a Commercial
+Contributor. If that Commercial Contributor then makes performance
+claims, or offers warranties related to Product X, those performance
+claims and warranties are such Commercial Contributor's responsibility
+alone. Under this section, the Commercial Contributor would have to
+defend claims against the other Contributors related to those performance
+claims and warranties, and if a court requires any other Contributor to
+pay any damages as a result, the Commercial Contributor must pay
+those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN "AS IS"
+BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF
+TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR
+PURPOSE. Each Recipient is solely responsible for determining the
+appropriateness of using and distributing the Program and assumes all
+risks associated with its exercise of rights under this Agreement,
+including but not limited to the risks and costs of program errors,
+compliance with applicable laws, damage to or loss of data, programs
+or equipment, and unavailability or interruption of operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS
+SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST
+PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of
+the remainder of the terms of this Agreement, and without further
+action by the parties hereto, such provision shall be reformed to the
+minimum extent necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that the
+Program itself (excluding combinations of the Program with other software
+or hardware) infringes such Recipient's patent(s), then such Recipient's
+rights granted under Section 2(b) shall terminate as of the date such
+litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it
+fails to comply with any of the material terms or conditions of this
+Agreement and does not cure such failure in a reasonable period of
+time after becoming aware of such noncompliance. If all Recipient's
+rights under this Agreement terminate, Recipient agrees to cease use
+and distribution of the Program as soon as reasonably practicable.
+However, Recipient's obligations under this Agreement and any licenses
+granted by Recipient relating to the Program shall continue and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement,
+but in order to avoid inconsistency the Agreement is copyrighted and
+may only be modified in the following manner. The Agreement Steward
+reserves the right to publish new versions (including revisions) of
+this Agreement from time to time. No one other than the Agreement
+Steward has the right to modify this Agreement. The Eclipse Foundation
+is the initial Agreement Steward. The Eclipse Foundation may assign the
+responsibility to serve as the Agreement Steward to a suitable separate
+entity. Each new version of the Agreement will be given a distinguishing
+version number. The Program (including Contributions) may always be
+Distributed subject to the version of the Agreement under which it was
+received. In addition, after a new version of the Agreement is published,
+Contributor may elect to Distribute the Program (including its
+Contributions) under the new version.
+
+Except as expressly stated in Sections 2(a) and 2(b) above, Recipient
+receives no rights or licenses to the intellectual property of any
+Contributor under this Agreement, whether expressly, by implication,
+estoppel or otherwise. All rights in the Program not expressly granted
+under this Agreement are reserved. Nothing in this Agreement is intended
+to be enforceable by any entity that is not a Contributor or Recipient.
+No third-party beneficiary rights are created under this Agreement.
+
+Exhibit A - Form of Secondary Licenses Notice
+
+"This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set forth
+in the Eclipse Public License, v. 2.0 are satisfied: {name license(s),
+version(s), and exceptions or additional permissions here}."
+
+  Simply including a copy of this Agreement, including this Exhibit A
+  is not sufficient to license the Source Code under Secondary Licenses.
+
+  If it is not possible or desirable to put the notice in a particular
+  file, then You may include the notice in a location (such as a LICENSE
+  file in a relevant directory) where a recipient would be likely to
+  look for such a notice.
+
+  You may add additional accurate notices of copyright ownership.
 
 
 ---

--- a/polaris-service/build.gradle.kts
+++ b/polaris-service/build.gradle.kts
@@ -23,6 +23,7 @@ plugins {
   alias(libs.plugins.quarkus)
   alias(libs.plugins.openapi.generator)
   id("polaris-server")
+  id("polaris-license-report")
   id("application")
 }
 


### PR DESCRIPTION
Added missing licenses reported by `./gradlew :polaris-service:checkLicense`

Manually verified via `./gradlew :polaris-service:licenseReportZip` and inspecting `polaris-service/build/reports/dependency-license/index.html`